### PR TITLE
style(cc): standardize extended thinking to Ultrathink keyword

### DIFF
--- a/cc/agents/orchestration-architect.md
+++ b/cc/agents/orchestration-architect.md
@@ -216,7 +216,7 @@ Validate the architecture against these requirements:
 
 ## Reasoning Approach
 
-Before producing output, engage in extended thinking:
+Ultrathink the orchestration design requirements, then produce output:
 
 1. **Enumerate patterns**: Consider all coordination patterns (Sequential, Parallel, Iterative,
    Hierarchical, State Machine) and their trade-offs for this specific workflow

--- a/cc/agents/plugin-improver.md
+++ b/cc/agents/plugin-improver.md
@@ -241,7 +241,7 @@ Validate the plugin against these requirements:
 
 ## Reasoning Approach
 
-Before producing output, engage in extended thinking:
+Ultrathink the plugin analysis requirements, then produce output:
 
 1. **Synthesize cross-component findings**: Look for patterns that span multiple components
    (naming inconsistencies, repeated issues, integration gaps)


### PR DESCRIPTION
## Summary

- Replace "engage in extended thinking" with "Ultrathink" verb pattern in cc plugin agents
- Standardizes keyword triggering for maximum reasoning depth activation

## Files Changed

- `cc/agents/orchestration-architect.md`: Updated reasoning approach section
- `cc/agents/plugin-improver.md`: Updated reasoning approach section

## Test plan

- [ ] Verify Ultrathink keyword triggers extended thinking in agent responses
- [ ] Confirm no "engage in extended thinking" references remain in cc plugin