### PR TITLE
chore(marketplace): remove unready plugins and rename brainstorm-pro

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "description": "Multi-agent requirements discovery through Socratic dialogue and systematic exploration for software/feature ideation",
       "source": "./brainstorm.claude",
       "category": "productivity",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "keywords": [
         "brainstorming",
         "requirements",

--- a/brainstorm.claude/.claude-plugin/plugin.json
+++ b/brainstorm.claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brainstorm",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Multi-agent requirements discovery through Socratic dialogue and systematic exploration for software/feature ideation. Transforms ambiguous ideas into actionable specifications through interactive dialogue and comprehensive analysis.",
   "author": {
     "name": "João da Silva",


### PR DESCRIPTION
## Summary
- Remove 9 plugins that are not yet ready for marketplace publication
- Rename brainstorm-pro to brainstorm for simplicity

## Plugins Removed
- job-hunting-pro
- docs-automation
- tdd-pro
- marketplace-curator
- jaodsilv-career
- community-git-tools
- community-testing
- community-devops
- community-bundle

## Plugins Retained
- brainstorm (renamed from brainstorm-pro)
- cc
- gitx
- planner

## Test plan
- [ ] Verify marketplace.json is valid JSON
- [ ] Verify the 4 remaining plugins are correctly listed