### PR TITLE
chore: version bumps to v2.0.0 and gitx v3.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "jaodsilv-claudius-marketplace",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "Personal productivity marketplace: TDD workflows, job hunting automation, and curated community development tools",
   "owner": {
     "name": "João da Silva",
@@ -13,7 +13,7 @@
       "description": "Multi-agent requirements discovery through Socratic dialogue and systematic exploration for software/feature ideation",
       "source": "./brainstorm.claude",
       "category": "productivity",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "keywords": [
         "brainstorming",
         "requirements",
@@ -29,7 +29,7 @@
       "description": "Meta-toolkit for creating, improving, and managing Claude Code plugin components. Requires plugin-dev@claude-plugins-official",
       "source": "./cc",
       "category": "development-workflow",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "keywords": [
         "meta-tools",
         "plugin-development",
@@ -45,7 +45,7 @@
       "description": "Extended git/GitHub workflow commands with multi-agent orchestration for worktrees, issues, PRs, conflict resolution, and branch operations",
       "source": "./gitx",
       "category": "git-version-control",
-      "version": "1.4.0",
+      "version": "2.0.0",
       "keywords": [
         "git",
         "github",
@@ -64,7 +64,7 @@
       "description": "Strategic planning plugin: multi-agent orchestrated roadmapping, issue prioritization, requirements discovery, and comprehensive planning reviews",
       "source": "./planner.claude",
       "category": "productivity",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "keywords": [
         "planning",
         "roadmap",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -45,7 +45,7 @@
       "description": "Extended git/GitHub workflow commands with multi-agent orchestration for worktrees, issues, PRs, conflict resolution, and branch operations",
       "source": "./gitx",
       "category": "git-version-control",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "keywords": [
         "git",
         "github",

--- a/brainstorm.claude/.claude-plugin/plugin.json
+++ b/brainstorm.claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "brainstorm",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Multi-agent requirements discovery through Socratic dialogue and systematic exploration for software/feature ideation. Transforms ambiguous ideas into actionable specifications through interactive dialogue and comprehensive analysis.",
   "author": {
     "name": "João da Silva",

--- a/cc/.claude-plugin/plugin.json
+++ b/cc/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cc",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Meta-toolkit for creating, improving, and managing Claude Code plugin components",
   "author": {
     "name": "Joao da Silva",

--- a/gitx/.claude-plugin/plugin.json
+++ b/gitx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gitx",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Extended git/GitHub workflow commands for Claude Code. Provides worktree management, issue tracking, PR workflows, and branch operations. Builds on commit-commands plugin. Requires: git, gh CLI. Optional: commit-commands@claude-plugins-official",
   "author": {
     "name": "Joao da Silva",

--- a/gitx/.claude-plugin/plugin.json
+++ b/gitx/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gitx",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Extended git/GitHub workflow commands for Claude Code. Provides worktree management, issue tracking, PR workflows, and branch operations. Builds on commit-commands plugin. Requires: git, gh CLI. Optional: commit-commands@claude-plugins-official",
   "author": {
     "name": "Joao da Silva",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudius",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "Claude Code configuration repository",
   "type": "module",
   "scripts": {

--- a/planner.claude/.claude-plugin/plugin.json
+++ b/planner.claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "planner",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Strategic planning plugin for project roadmapping, issue prioritization, and deep ideation. Features multi-agent orchestrated reviews with adversarial analysis, Ultrathink-powered ideation with Opus, deep GitHub integration via gh CLI, and optional brainstorm-pro integration.",
   "author": {
     "name": "Joao da Silva",

--- a/tmpclaude-19cd-cwd
+++ b/tmpclaude-19cd-cwd
@@ -1,0 +1,1 @@
+/d/src/claudius/pr9-version-bumps

--- a/tmpclaude-94e9-cwd
+++ b/tmpclaude-94e9-cwd
@@ -1,0 +1,1 @@
+/d/src/claudius/pr9-version-bumps

--- a/tmpclaude-9c82-cwd
+++ b/tmpclaude-9c82-cwd
@@ -1,0 +1,1 @@
+/d/src/claudius/pr9-version-bumps

--- a/tmpclaude-e310-cwd
+++ b/tmpclaude-e310-cwd
@@ -1,0 +1,1 @@
+/d/src/claudius/pr9-version-bumps

--- a/tmpclaude-f2d6-cwd
+++ b/tmpclaude-f2d6-cwd
@@ -1,0 +1,1 @@
+/d/src/claudius/pr9-version-bumps

--- a/tmpclaude-f79a-cwd
+++ b/tmpclaude-f79a-cwd
@@ -1,0 +1,1 @@
+/d/src/claudius/pr9-version-bumps


### PR DESCRIPTION
## Summary
- Bump brainstorm, cc, gitx, planner plugins to v2.0.0
- Bump gitx to v3.0.0 (additional major changes)
- Update package.json to v2.0.0
- Update marketplace.json version references

## Dependencies
**Requires ALL PRs #66-73 to be merged first**

## Changes
- 2 commits: v2.0.0 bump, gitx v3.0.0 bump
- Updates all plugin.json files and marketplace.json

## Test Plan
- Verify plugin versions display correctly
- Check marketplace.json is valid