### PR TITLE
fix(hooks): resolve SessionStart hook failures

### DIFF
--- a/cc/hooks/hooks.json
+++ b/cc/hooks/hooks.json
@@ -1,15 +1,3 @@
 {
-  "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "The cc plugin requires plugin-dev@claude-plugins-official to be installed. If the user attempts to use cc commands or agents and plugin-dev skills are not available, inform them to install it first with: /plugin install plugin-dev@claude-plugins-official"
-          }
-        ]
-      }
-    ]
-  }
+  "hooks": {}
 }

--- a/gitx/hooks/hooks.json
+++ b/gitx/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'command -v bash >/dev/null 2>&1 && bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/check-dependencies.sh\"' 2>&1 || powershell -ExecutionPolicy Bypass -File \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/check-dependencies.ps1\"",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/check-dependencies.sh",
             "timeout": 10
           }
         ]


### PR DESCRIPTION
## Summary
- Remove cc plugin prompt hook (`type: "prompt"` is unsupported at SessionStart - causes "ToolUseContext is required for prompt hooks" error)
- Simplify gitx hook command to just script path per documentation (complex bash/powershell fallback was unnecessary)

## Test plan
- [ ] Restart Claude Code session - no hook errors should appear
- [ ] Verify gitx dependency checking still works (git/gh detection)